### PR TITLE
add incremental kapt support

### DIFF
--- a/RoomigrantCompiler/build.gradle
+++ b/RoomigrantCompiler/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'kotlin-kapt'
 
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
@@ -14,4 +15,8 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'android.arch.persistence.room:runtime:1.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc6'
+    compileOnly 'net.ltgt.gradle.incap:incap:0.2'
+    kapt 'net.ltgt.gradle.incap:incap-processor:0.2'
 }

--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/RoomigrantProcessor.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/RoomigrantProcessor.kt
@@ -1,13 +1,18 @@
 package dev.matrix.roomigrant.compiler
 
+import com.google.auto.service.AutoService
 import com.google.gson.Gson
 import com.squareup.kotlinpoet.asClassName
 import dev.matrix.roomigrant.GenerateRoomMigrations
 import dev.matrix.roomigrant.compiler.data.Root
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessor
+import net.ltgt.gradle.incap.IncrementalAnnotationProcessorType.ISOLATING
 import java.io.File
 import java.io.InputStreamReader
 import javax.annotation.processing.AbstractProcessor
+import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
+import javax.annotation.processing.SupportedSourceVersion
 import javax.lang.model.SourceVersion
 import javax.lang.model.element.TypeElement
 import android.arch.persistence.room.Database as DatabaseAnnotation
@@ -15,7 +20,10 @@ import android.arch.persistence.room.Database as DatabaseAnnotation
 /**
  * @author matrixdev
  */
-class Processor : AbstractProcessor() {
+@AutoService(Processor::class)
+@IncrementalAnnotationProcessor(ISOLATING)
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
+class RoomigrantProcessor : AbstractProcessor() {
 
 	override fun getSupportedSourceVersion() = SourceVersion.latestSupported()!!
 	override fun getSupportedAnnotationTypes() = mutableSetOf(GenerateRoomMigrations::class.java.name)

--- a/RoomigrantCompiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/RoomigrantCompiler/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,1 @@
-dev.matrix.roomigrant.compiler.Processor
+dev.matrix.roomigrant.compiler.RoomigrantProcessor


### PR DESCRIPTION
It's worth noting that Room only supports incremental kapt on JDK 11+ and Roomigrant is bound to be applied to the same module, so for some devs this may not be enough to actually get incremental kapt working.

Fixes #3