### PR TITLE
supporting changing indexed field affinity

### DIFF
--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
@@ -133,13 +133,13 @@ class Migration(
                 dropTableIndex(it)
                 createTableIndex(table2, it)
             }
-            tableDiff.indicesDiff.added.forEach {
-                createTableIndex(table2, it)
-            }
             tableDiff.indicesDiff.removed.forEach {
                 dropTableIndex(it)
-            }
-        }
+			}
+			tableDiff.indicesDiff.added.forEach {
+                createTableIndex(table2, it)
+			}
+		}
 
         for (table in diff.removedTables) {
             dropTable(table.name)

--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/Migration.kt
@@ -135,11 +135,11 @@ class Migration(
             }
             tableDiff.indicesDiff.removed.forEach {
                 dropTableIndex(it)
-			}
-			tableDiff.indicesDiff.added.forEach {
+            }
+            tableDiff.indicesDiff.added.forEach {
                 createTableIndex(table2, it)
-			}
-		}
+            }
+        }
 
         for (table in diff.removedTables) {
             dropTable(table.name)

--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/diff/IndicesDiff.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/diff/IndicesDiff.kt
@@ -9,7 +9,8 @@ import dev.matrix.roomigrant.compiler.data.Table
 @Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
 class IndicesDiff(val table1: Table?, val table2: Table) {
 
-    data class IndexColumnAffinity(val name: String, val affinity: String, val notNull: Boolean)
+    private data class IndexIdentity(val fields: Set<IndexFieldIdentity>)
+    private data class IndexFieldIdentity(val name: String, val affinity: String, val notNull: Boolean)
 
     val same = ArrayList<Index>()
     val added = ArrayList<Index>()
@@ -29,26 +30,32 @@ class IndicesDiff(val table1: Table?, val table2: Table) {
             return
         }
 
-        val oldIndicesNameMap = table1.indices.associateByTo(HashMap()) {
-            it.columns.sorted().map { columnName ->
-                val field = table1.fieldsMap[columnName] ?: error("unable to find field $columnName")
-                IndexColumnAffinity(field.name, field.affinity, field.notNull)
-            }
+        val oldIndicesMap = table1.indices.associateByTo(HashMap()) {
+            buildIndexIdentity(table1, it)
         }
 
         for (newIndex in table2.indices) {
-            val pairs = newIndex.columns.sorted().map { columnName ->
-                val field = table2.fieldsMap[columnName] ?: error("unable to find field $columnName")
-                IndexColumnAffinity(field.name, field.affinity, field.notNull)
-            }
-
-            val oldIndex = oldIndicesNameMap.remove(pairs)
-            when (oldIndex) {
+            val newIndexIdentity = buildIndexIdentity(table2, newIndex)
+            when (oldIndicesMap.remove(newIndexIdentity)) {
                 null -> added.add(newIndex)
                 newIndex -> same.add(newIndex)
                 else -> changed.add(newIndex)
             }
         }
-        removed.addAll(oldIndicesNameMap.values)
+        removed.addAll(oldIndicesMap.values)
+    }
+
+    private fun buildIndexIdentity(table: Table, index: Index): IndexIdentity {
+        val fields = index.columns.mapTo(HashSet()) {
+            buildIndexFieldIdentity(table, it)
+        }
+        return IndexIdentity(fields = fields)
+    }
+
+    private fun buildIndexFieldIdentity(table: Table, columnName: String): IndexFieldIdentity {
+        val field = checkNotNull(table.fieldsMap[columnName]) {
+            "unable to find field ${table.name}.$columnName"
+        }
+        return IndexFieldIdentity(field.name, field.affinity, field.notNull)
     }
 }

--- a/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/diff/IndicesDiff.kt
+++ b/RoomigrantCompiler/src/main/java/dev/matrix/roomigrant/compiler/diff/IndicesDiff.kt
@@ -9,6 +9,8 @@ import dev.matrix.roomigrant.compiler.data.Table
 @Suppress("CanBeParameter", "MemberVisibilityCanBePrivate")
 class IndicesDiff(val table1: Table?, val table2: Table) {
 
+    data class IndexColumnAffinity(val name: String, val affinity: String, val notNull: Boolean)
+
     val same = ArrayList<Index>()
     val added = ArrayList<Index>()
     val removed = ArrayList<Index>()
@@ -27,33 +29,26 @@ class IndicesDiff(val table1: Table?, val table2: Table) {
             return
         }
 
-        val oldIndicesNameMap = table1.indices.associateByTo(mutableMapOf()) {
+        val oldIndicesNameMap = table1.indices.associateByTo(HashMap()) {
+            it.columns.sorted().map { columnName ->
+                val field = table1.fieldsMap[columnName] ?: error("unable to find field $columnName")
+                IndexColumnAffinity(field.name, field.affinity, field.notNull)
+            }
+        }
 
-			it.columns.sorted().map { columnName ->
-				val field = table1.fieldsMap[columnName] ?: error("unable to find field $columnName")
-				IndexColumnAffinity(field.name, field.affinity, field.notNull)
-			}
-		}
+        for (newIndex in table2.indices) {
+            val pairs = newIndex.columns.sorted().map { columnName ->
+                val field = table2.fieldsMap[columnName] ?: error("unable to find field $columnName")
+                IndexColumnAffinity(field.name, field.affinity, field.notNull)
+            }
 
-		for (newIndex in table2.indices) {
-
-			val pairs = newIndex.columns.sorted().map { columnName ->
-				val field = table2.fieldsMap[columnName] ?: error("unable to find field $columnName")
-
-				IndexColumnAffinity(field.name, field.affinity, field.notNull)
-			}
-
-			val oldIndex = oldIndicesNameMap.remove(pairs)
-
-			when (oldIndex) {
+            val oldIndex = oldIndicesNameMap.remove(pairs)
+            when (oldIndex) {
                 null -> added.add(newIndex)
                 newIndex -> same.add(newIndex)
-				else     -> changed.add(newIndex)
-			}
-		}
-		removed.addAll(oldIndicesNameMap.values)
-	}
-
-	data class IndexColumnAffinity(val name: String, val affinity: String, val notNull: Boolean)
-
+                else -> changed.add(newIndex)
+            }
+        }
+        removed.addAll(oldIndicesNameMap.values)
+    }
 }

--- a/RoomigrantTest/schemas/dev.matrix.roomigrant.test.Database/10.json
+++ b/RoomigrantTest/schemas/dev.matrix.roomigrant.test.Database/10.json
@@ -1,0 +1,132 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "b0e2fae162b1acd1a54dd736ccd1274d",
+    "entities": [
+      {
+        "tableName": "Object1Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `intValRenamed` INTEGER NOT NULL, `stringValRenamed` TEXT NOT NULL, `nullIntVal` INTEGER, `nullStringVal` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "intValRenamed",
+            "columnName": "intValRenamed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stringValRenamed",
+            "columnName": "stringValRenamed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nullIntVal",
+            "columnName": "nullIntVal",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nullStringVal",
+            "columnName": "nullStringVal",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Object2Dbo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "special-chars",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`primary-id` TEXT NOT NULL, PRIMARY KEY(`primary-id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "primary-id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "primary-id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "indices",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "id_index",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `id_index` ON `${TABLE_NAME}` (`id`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [
+      {
+        "viewName": "ObjectDboView",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT item.id AS oneId, (SELECT id FROM Object2Dbo WHERE id = item.id) AS twoId  FROM Object1Dbo item"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b0e2fae162b1acd1a54dd736ccd1274d')"
+    ]
+  }
+}

--- a/RoomigrantTest/src/androidTest/java/dev/matrix/roomigrant/test/DatabaseTest.kt
+++ b/RoomigrantTest/src/androidTest/java/dev/matrix/roomigrant/test/DatabaseTest.kt
@@ -19,7 +19,7 @@ class DatabaseTest {
     fun testMigration() {
         val name = "migration_test.db"
         val db = migrationHelper.createDatabase(name, 1).let {
-            migrationHelper.runMigrationsAndValidate(name, 8, true, *Database_Migrations.build())
+            migrationHelper.runMigrationsAndValidate(name, 10, true, *Database_Migrations.build())
         }
         db.close()
     }

--- a/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/Database.kt
+++ b/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/Database.kt
@@ -10,9 +10,10 @@ import dev.matrix.roomigrant.GenerateRoomMigrations
  * 7 - Add ObjectDboView
  * 8 - Add twoId to ObjectDboView
  * 9 - Special characters, indices
+ * 10 - Change Indices indexed ID from String to Int
  */
 @Database(
-        version = 9,
+        version = 10,
         entities = [Object1Dbo::class, Object2Dbo::class, SpecialCharsDbo::class, IndicesDbo::class],
         views = [ObjectDboView::class]
 )

--- a/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/IndicesDbo.kt
+++ b/RoomigrantTest/src/main/java/dev/matrix/roomigrant/test/IndicesDbo.kt
@@ -10,5 +10,5 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "indices", indices = [Index(name = "id_index", value = ["id"])])
 class IndicesDbo {
     @PrimaryKey
-    var id = ""
+    var id = 1
 }


### PR DESCRIPTION
For each index, get each column name from the `columns` list.  
For each column name, find the actual field in the `fieldsMap` property of the `Field`.  
Create tuples for each field which represent the name, affinity, and nullability.
When comparing indices, compare their lists of these tuples instead of just the column names.

Fixes #16